### PR TITLE
fix:java.lang.IllegalArgumentException

### DIFF
--- a/okdownload-breakpoint-sqlite/src/main/java/com/liulishuo/okdownload/core/breakpoint/BlockInfoRow.java
+++ b/okdownload-breakpoint-sqlite/src/main/java/com/liulishuo/okdownload/core/breakpoint/BlockInfoRow.java
@@ -32,9 +32,9 @@ public class BlockInfoRow {
 
     public BlockInfoRow(Cursor cursor) {
         this.breakpointId = cursor.getInt(cursor.getColumnIndex(HOST_ID));
-        this.startOffset = cursor.getInt(cursor.getColumnIndex(START_OFFSET));
-        this.contentLength = cursor.getInt(cursor.getColumnIndex(CONTENT_LENGTH));
-        this.currentOffset = cursor.getInt(cursor.getColumnIndex(CURRENT_OFFSET));
+        this.startOffset = cursor.getLong(cursor.getColumnIndex(START_OFFSET));
+        this.contentLength = cursor.getLong(cursor.getColumnIndex(CONTENT_LENGTH));
+        this.currentOffset = cursor.getLong(cursor.getColumnIndex(CURRENT_OFFSET));
     }
 
     public int getBreakpointId() {


### PR DESCRIPTION
java.lang.IllegalArgumentException
	at com.liulishuo.okdownload.core.breakpoint.BlockInfo.<init>(SourceFile:6)
	at com.liulishuo.okdownload.core.breakpoint.BlockInfoRow.toInfo(Unknown Source:9)
	at com.liulishuo.okdownload.core.breakpoint.BreakpointSQLiteHelper.loadToCache(SourceFile:19)
	at com.liulishuo.okdownload.core.breakpoint.BreakpointStoreOnSQLite.<init>(SourceFile:6)